### PR TITLE
feat: Add check for account existence before login and display error message if not found

### DIFF
--- a/config/devdojo/auth/descriptions.php
+++ b/config/devdojo/auth/descriptions.php
@@ -16,5 +16,6 @@ return [
         'login_show_social_providers' => 'Show the social providers login buttons on the login form',
         'center_align_social_provider_button_content' => 'Center align the content in the social provider button?',
         'social_providers_location' => 'The location of the social provider buttons (top or bottom)',
+        'check_account_exists_before_login' => 'Determines if the system checks for account existence before login',
     ],
 ];

--- a/config/devdojo/auth/language.php
+++ b/config/devdojo/auth/language.php
@@ -19,6 +19,7 @@ return [
         'sign_up' => 'Sign up',
         'social_auth_authenticated_message' => 'You have been authenticated via __social_providers_list__. Please login to that network below.',
         'change_email' => 'Change Email',
+        'couldnt_find_your_account' => "Couldn’t find your account",
     ],
     'register' => [
         'page_title' => 'Sign up',

--- a/config/devdojo/auth/settings.php
+++ b/config/devdojo/auth/settings.php
@@ -15,4 +15,5 @@ return [
     'login_show_social_providers' => true,
     'center_align_social_provider_button_content' => false,
     'social_providers_location' => 'bottom',
+    'check_account_exists_before_login' => false,
 ];

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -72,6 +72,14 @@ new class extends Component
                     return;
                 }
             }
+
+            // Check if account exists before login and handle error if user is not found
+            if(config('devdojo.auth.settings.check_account_exists_before_login') && is_null($userTryingToValidate)){
+                $this->js("setTimeout(function(){ window.dispatchEvent(new CustomEvent('focus-email', {})); }, 10);");
+                $this->addError('email', trans(config('devdojo.auth.language.login.couldnt_find_your_account')));
+                return;
+            }
+
             $this->showPasswordField = true;
             $this->js("setTimeout(function(){ window.dispatchEvent(new CustomEvent('focus-password', {})); }, 10);");
             return;
@@ -125,7 +133,7 @@ new class extends Component
 ?>
 
 <x-auth::layouts.app title="{{ config('devdojo.auth.language.login.page_title') }}">
-    
+
     @volt('auth.login')
         <x-auth::elements.container>
 
@@ -168,7 +176,7 @@ new class extends Component
 
                 @if($showPasswordField)
                     <x-auth::elements.input :label="config('devdojo.auth.language.login.password')" type="password" wire:model="password" id="password" data-auth="password-input" />
-					<x-auth::elements.checkbox :label="config('devdojo.auth.language.login.remember_me')" wire:model="rememberMe" id="remember-me" data-auth="remember-me-input" />                                   
+					<x-auth::elements.checkbox :label="config('devdojo.auth.language.login.remember_me')" wire:model="rememberMe" id="remember-me" data-auth="remember-me-input" />
 					<div class="flex justify-between items-center mt-6 text-sm leading-5">
                         <x-auth::elements.text-link href="{{ route('auth.password.request') }}" data-auth="forgot-password-link">{{ config('devdojo.auth.language.login.forget_password') }}</x-auth::elements.text-link>
                     </div>
@@ -191,5 +199,5 @@ new class extends Component
 
         </x-auth::elements.container>
     @endvolt
-    
+
 </x-auth::layouts.app>


### PR DESCRIPTION
This feature introduces an option that allows the system to verify the existence of a user account before proceeding with the login process. The primary goal is to enhance security and user experience by ensuring that only existing accounts can attempt to log in.

### Key Changes:
- **New Configuration Option**: `check_account_exists_before_login`
  - This option can be enabled or disabled to control whether the system verifies account availability during the login process.
  
- **Error Handling**: 
  - If the account is not found, a message saying "Couldn’t find your account" will be displayed to the user.

### Benefits:
- **Enhanced Security**: Prevents login attempts with non-existent accounts.
- **Improved User Feedback**: Provides clear feedback when an account is not found.
  
This feature provides flexibility for applications that require pre-login account validation and improves the overall user experience during authentication.

> **Note:** Inspired by the account verification flow in Google login. 😉
